### PR TITLE
Add a job linter

### DIFF
--- a/.cyclid.json
+++ b/.cyclid.json
@@ -1,69 +1,89 @@
 {
+   "name" : "Cyclid-core",
+   "environment" : {
+      "os" : "ubuntu_trusty",
+      "repos": [
+        {
+          "url": "ppa:brightbox/ruby-ng"
+        }
+      ],
+      "packages" : [
+         "ruby2.3",
+         "ruby2.3-dev",
+         "build-essential",
+         "git"
+      ]
+   },
    "stages" : [
       {
+         "name" : "bundle-install",
          "steps" : [
             {
                "action" : "command",
-               "cmd" : "sudo gem2.0 install bundler --no-ri --no-doc"
+               "cmd" : "sudo gem install bundler --no-ri --no-doc"
             },
             {
                "path" : "%{workspace}/Cyclid-core",
                "action" : "command",
                "cmd" : "bundle install --path vendor/bundle"
             }
-         ],
-         "name" : "bundle-install"
+         ]
       },
       {
+         "name" : "lint",
          "steps" : [
             {
                "cmd" : "bundle exec rake rubocop",
                "path" : "%{workspace}/Cyclid-core",
                "action" : "command"
             }
-         ],
-         "name" : "lint"
+         ]
       },
       {
+         "name" : "build",
          "steps" : [
             {
                "cmd" : "bundle exec rake build",
                "path" : "%{workspace}/Cyclid-core",
                "action" : "command"
             }
-         ],
-         "name" : "build"
+         ]
+      },
+      {
+        "name": "success",
+        "steps": [
+          {
+            "action" : "slack",
+            "subject" : "%{job_name} succeeded",
+            "message" : "Build %{organization}/%{job_name} (job #%{job_id}) completed successfully."
+          }
+        ]
+      },
+      {
+        "name": "failure",
+        "steps": [
+          {
+            "action" : "slack",
+            "subject" : "%{job_name} failed",
+            "message" : "Build %{organization}/%{job_name} (job #%{job_id}) failed.",
+            "color" : "danger"
+          }
+        ]
       }
    ],
-   "environment" : {
-      "packages" : [
-         "ruby2.0",
-         "ruby2.0-dev"
-      ],
-      "os" : "ubuntu_trusty"
-   },
-   "name" : "Cyclid-core",
    "sequence" : [
       {
          "stage" : "bundle-install",
-         "on_success" : "lint",
          "on_failure" : "failure"
       },
       {
          "stage" : "lint",
-         "on_success" : "test",
          "on_failure" : "failure"
       },
       {
-         "on_success" : "success",
          "stage" : "build",
+         "on_success" : "success",
          "on_failure" : "failure"
-      },
-      {
-         "stage" : "success"
-      },
-      {
-         "stage" : "failure"
       }
    ]
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,27 @@
 PATH
   remote: .
   specs:
-    cyclid-core (0.1.1)
+    cyclid-core (0.2.0)
+      activesupport (~> 4.2)
       rack (~> 1.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (4.2.9)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     ast (2.2.0)
     docile (1.1.5)
+    i18n (0.8.4)
     json (1.8.3)
+    minitest (5.10.2)
     parser (2.3.0.7)
       ast (~> 2.2)
     powerpack (0.1.1)
-    rack (1.6.4)
+    rack (1.6.8)
     rainbow (2.1.0)
     rake (11.1.2)
     rubocop (0.39.0)
@@ -29,6 +37,9 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
     unicode-display_width (1.0.3)
 
 PLATFORMS
@@ -42,4 +53,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/cyclid-core.gemspec
+++ b/cyclid-core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cyclid-core'
-  s.version     = '0.1.1'
+  s.version     = '0.2.0'
   s.licenses    = ['MIT', 'Apache-2.0']
   s.summary     = 'Core files for Cyclid'
   s.description = 'Core files (shared between the Client & Server) for Cyclid'
@@ -9,4 +9,5 @@ Gem::Specification.new do |s|
   s.files       = Dir.glob('lib/**/*') + %w(LICENSE README.md)
 
   s.add_runtime_dependency('rack', '~> 1.6')
+  s.add_runtime_dependency('activesupport', '~> 4.2')
 end

--- a/lib/cyclid/linter.rb
+++ b/lib/cyclid/linter.rb
@@ -1,0 +1,178 @@
+
+require 'active_support'
+require 'active_support/core_ext'
+require 'json'
+require 'yaml'
+require 'colorize'
+
+module Cyclid
+  module Linter
+    # A simple helper to track Warnings & Errors from the Verifier
+    class StatusLogger
+      attr_reader :messages, :warnings, :errors
+
+      module MessageTypes
+        WARNING = 0
+        ERROR = 1
+      end
+
+      def initialize
+        @messages = []
+        @warnings = 0
+        @errors = 0
+      end
+
+      def warning(message)
+        @warnings += 1
+        @messages << { type: MessageTypes::WARNING, text: message }
+      end
+
+      def error(message)
+        @errors += 1
+        @messages << { type: MessageTypes::ERROR, text: message }
+      end
+    end
+
+    # Verify (lint) a Job for obvious errors and potential problems
+    class Verifier
+      module Bertrand
+        UNKNOWN = 0
+        NOT_EXIST = 1
+        EXISTS = 2
+      end
+
+      attr_reader :status
+
+      def initialize(_args)
+        @status = StatusLogger.new
+      end
+
+      def verify(job)
+        job.deep_symbolize_keys!
+
+        # Does the data even look like a job?
+        @status.error 'Job is not a hash?' \
+          unless job.is_a? Hash
+
+        @status.error 'Job is empty?' \
+          if job.empty?
+
+        # Lint all of the obvious, top-level stuff that makes up a basic job
+        @status.error 'The Job does not have a name.' \
+          unless job.key? :name
+
+        @status.warning 'No version is defined for the Job. The default of 1.0.0 will be used.' \
+          unless job.key? :version
+
+        @status.warning 'No environment is defined. Defaults will apply.' \
+          unless job.key? :environment
+
+        @status.error 'No sequence is defined.' \
+          unless job.key? :sequence
+
+        # If any Stages are defined, check that each one looks valid
+        verify_stages(job[:stages]) if job.key? :stages
+
+        # Verify that the Sequence is valid, as much as possible
+        verify_sequence(job[:sequence]) if job.key? :sequence
+      rescue StandardError => ex
+        @status.error "An unexpected error occured during the verification: #{ex}"
+      end
+
+      private
+
+      def verify_stages(stages)
+        @status.error 'Stages is not defined as an Array.' \
+          unless stages.is_a? Array
+
+        @status.warning 'Stages is defined but empty?' \
+          if stages.empty?
+
+        # Verify each Stage
+        @ad_hoc_stages = []
+        stages.each do |stage|
+          unless stage.is_a? Hash
+            @status.error 'A Stage is defined but is not an Object?'
+            next
+          end
+
+          unless stage.key? :name
+            @status.error 'A Stage is defined without a name.'
+            next
+          end
+
+          # The Stage is at least a Hash with a name key...
+          name = stage[:name]
+          @ad_hoc_stages << name
+
+          @status.error "The Stage '#{name}' is defined but empty." \
+            if stage.empty?
+
+          unless stage.key? :steps
+            @status.error "The Stage '#{name}' does not define any Steps."
+            next
+          end
+
+          @status.error "The Stage '#{name}' defines an empty set of Steps." \
+            if stage[:steps].empty?
+
+          @status.warning "No version is given for the Stage '#{name}'. " \
+            'The default of 1.0.0 will be used.' \
+            unless stage.key? :version
+        end
+      end
+
+      def verify_sequence(sequence)
+        @status.error 'The Sequence is not defined as an Array.' \
+          unless sequence.is_a? Array
+
+        @status.error 'The Sequence is defined but empty?' \
+          if sequence.empty?
+
+        # Verify each Stage and track all dependencies (stage, on_success, on_failure)
+        dependencies = []
+        sequence.each do |stage|
+          unless stage.is_a? Hash
+            @status.error 'A Stage in the Sequence is defined that is not an Object?'
+            next
+          end
+
+          unless stage.key? :stage
+            @status.error 'A Stage in the Sequence does not name a Stage to run.'
+            next
+          end
+
+          name = stage[:stage]
+          @status.warning 'A Stage in the Sequence does not specify a version for the ' \
+            "Stage '#{name}'. The latest will always be used."
+
+          dependencies << name.downcase
+          dependencies << stage[:on_success].downcase if stage.key? :on_success
+          dependencies << stage[:on_failure].downcase if stage.key? :on_failure
+        end
+        dependencies.uniq!
+
+        # Check that every dependency exists
+        dependencies.each do |dep|
+          next if @ad_hoc_stages.include? dep
+
+          # Okay, it's not defined in this job: does it exist on the server?
+          case stage_exists? dep
+          when Bertrand::UNKNOWN
+            @status.warning "The Stage '#{dep}' in the Sequence is not defined in this job and " \
+              'may not exist on the server.'
+          when Bertrand::NOT_EXIST
+            @status.error "The Stage '#{dep}' in the Sequence is not defined in this job and " \
+              'does not exist on the server.'
+          end
+        end
+      end
+
+      # Find a Stage by it's name; this method will difer between Remote & Local
+      # (server-side) verification, so is just a stub here.
+      def stage_exists?(_name)
+        Bertrand::UNKNOWN
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a Linter that can catch obvious errors & ommisions in a Job definition. The core class implements the bulk of the functionality and it is intended to be used by both the Client to Lint a job locally and by the API to lint a job prior to dispatch and provide useful information back to the user.